### PR TITLE
Hotfix/peakforest new url (#215)

### DIFF
--- a/R/BiodbDbsInfo.R
+++ b/R/BiodbDbsInfo.R
@@ -114,8 +114,8 @@ BiodbDbsInfo$methods( .initDbsInfo = function() {
 	.self$.define('ncbi.gene',              name = 'NCBI Gene', scheduler.n = 3, entry.content.type = 'xml', base.url = 'https://www.ncbi.nlm.nih.gov/', ws.url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/') # About access frequency, see https://www.ncbi.nlm.nih.gov/books/NBK25497/
 	.self$.define('ncbi.pubchem.comp',      name = 'PubChem Compound', scheduler.n = 5, entry.content.type = 'xml', base.url = 'https://pubchem.ncbi.nlm.nih.gov/', ws.url = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/') # About access frequency, see https://pubchem.ncbi.nlm.nih.gov/pug_rest/PUG_REST.html
 	.self$.define('ncbi.pubchem.subst',     name = 'PubChem Substance', scheduler.n = 5, entry.content.type = 'xml', base.url = 'https://pubchem.ncbi.nlm.nih.gov/', ws.url = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/') # About access frequency, see https://pubchem.ncbi.nlm.nih.gov/pug_rest/PUG_REST.html
-	.self$.define('peakforest.mass',        name = 'PeakForest Mass', scheduler.n = 3, entry.content.type = 'json', base.url = 'https://rest.peakforest.org/')
-	.self$.define('peakforest.compound',    name = 'PeakForest Compound', scheduler.n = 3, entry.content.type = 'json', base.url = 'https://rest.peakforest.org/')
+	.self$.define('peakforest.mass',        name = 'PeakForest Mass', scheduler.n = 3, entry.content.type = 'json', base.url = 'https://metabohub.peakforest.org/rest/')
+	.self$.define('peakforest.compound',    name = 'PeakForest Compound', scheduler.n = 3, entry.content.type = 'json', base.url = 'https://metabohub.peakforest.org/rest/')
 	.self$.define('uniprot',                name = 'UniProt',                  entry.content.type = 'xml', base.url = 'http://www.uniprot.org/uniprot/', xml.ns = "http://uniprot.org/uniprot")
 })
 

--- a/R/HmdbMetabolitesConn.R
+++ b/R/HmdbMetabolitesConn.R
@@ -91,8 +91,8 @@ HmdbMetabolitesConn$methods( .doExtractDownload = function() {
 	.self$message('debug', "Extract entries from XML file.")
 	chunk.size <- 2**16
 	total.bytes <- file.info(xml.file)$size
-	bytes.read <- as.integer(0)
-	last.msg.bytes.index <- as.integer(0)
+	bytes.read <- 0
+	last.msg.bytes.index <- 0
 	xml.chunks <- character()
 	.self$message('debug', paste("Read XML file by chunk of", chunk.size, "characters."))
 	done.reading <- FALSE

--- a/R/MassdbConn.R
+++ b/R/MassdbConn.R
@@ -124,7 +124,7 @@ MassdbConn$methods( searchMzTol = function(mz, mz.tol, mz.tol.unit = BIODB.MZTOL
 # Search MS peaks {{{1
 ################################################################
 
-MassdbConn$methods ( searchMsPeaks = function(mzs, mz.tol, mz.tol.unit = BIODB.MZTOLUNIT.PLAIN, min.rel.int = NA_real_, ms.mode = NA_character_, max.results = NA_integer_) {
+MassdbConn$methods ( searchMsPeaks = function(mzs, mz.tol, mz.tol.unit = BIODB.MZTOLUNIT.PLAIN, min.rel.int = NA_real_, ms.mode = NA_character_, ms.level = 0, max.results = NA_integer_) {
 	":\n\nFor each M/Z value, search for matching MS spectra and return the matching peaks. If max.results is set, it is used to limit the number of matches found for each M/Z value."
 
 	if ( ! .self$.assert.not.na(mzs, msg.type = 'warning')) return(NULL)
@@ -145,7 +145,7 @@ MassdbConn$methods ( searchMsPeaks = function(mzs, mz.tol, mz.tol.unit = BIODB.M
 
 		# Search for spectra
 		.self$message('debug', paste('Searching for spectra that contains M/Z value ', mz, '.', sep = ''))
-		ids <- .self$searchMzTol(mz, mz.tol = mz.tol, mz.tol.unit = mz.tol.unit, min.rel.int = min.rel.int, ms.mode = ms.mode, max.results = max.results, ms.level = 1)
+		ids <- .self$searchMzTol(mz, mz.tol = mz.tol, mz.tol.unit = mz.tol.unit, min.rel.int = min.rel.int, ms.mode = ms.mode, max.results = max.results, ms.level = ms.level)
 
 		# Get entries
 		.self$message('debug', 'Getting entries from spectra IDs.')

--- a/R/PeakforestCompoundConn.R
+++ b/R/PeakforestCompoundConn.R
@@ -33,7 +33,7 @@ PeakforestCompoundConn$methods( .doGetEntryContentUrl = function(id, concatenate
 ################################################################
 
 PeakforestCompoundConn$methods( getEntryPageUrl = function(id) {
-	return(paste('https://peakforest.org/home?PFc=', id))
+	return(paste('https://metabohub.peakforest.org/webapp/home?PFc=', id))
 })
 
 # Get entry image url {{{1

--- a/R/PeakforestMassConn.R
+++ b/R/PeakforestMassConn.R
@@ -41,7 +41,7 @@ PeakforestMassConn$methods( .doGetEntryContentUrl = function(id, concatenate = T
 ################################################################
 
 PeakforestMassConn$methods( getEntryPageUrl = function(id) {
-	return(paste('https://peakforest.org/home?PFs=', id))
+	return(paste('https://metabohub.peakforest.org/webapp/home?PFs=', id))
 })
 
 # Get entry image url {{{1

--- a/tests/testthat/common.R
+++ b/tests/testthat/common.R
@@ -90,13 +90,13 @@ if ('FUNCTIONS' %in% names(env)) {
 # Test observer {{{1
 ################################################################
 
-TestObserver <- methods::setRefClass('TestObserver', contains = 'BiodbObserver', fields = list(.last.index = 'integer'))
+TestObserver <- methods::setRefClass('TestObserver', contains = 'BiodbObserver', fields = list(.last.index = 'numeric'))
 
 TestObserver$methods( initialize = function(...) {
 
 	callSuper(...)
 
-	.last.index <<- as.integer(0)
+	.last.index <<- 0
 })
 
 TestObserver$methods( progress = function(type = 'info', msg, index, total) {
@@ -107,9 +107,9 @@ TestObserver$methods( progress = function(type = 'info', msg, index, total) {
 	expect_lte(index, total)
 
 	if (index == total)
-		.last.index <<- as.integer(0)
+		.last.index <<- 0
 	else
-		.last.index <<- as.integer(index)
+		.last.index <<- index
 })
 
 # Create Biodb instance {{{1

--- a/tests/testthat/db-ms-tests.R
+++ b/tests/testthat/db-ms-tests.R
@@ -214,22 +214,25 @@ test.getChromCol <- function(db) {
 test.searchMsPeaks <- function(db) {
 
 	mode <- 'neg'
+	tol <- 0.1
 
 	mzs <- db$getMzValues(ms.mode = mode, max.results = 3)
 
 	# Get only one result per M/Z value
-	results <- db$searchMsPeaks(mzs, mz.tol = 0.1, max.results = 1, ms.mode = mode)
+	results <- db$searchMsPeaks(mzs, mz.tol = tol, max.results = 1, ms.mode = mode)
 	expect_is(results, 'data.frame')
 	expect_true(nrow(results) >= 1)
 	expect_true('accession' %in% names(results))
 	expect_true('peak.mz' %in% names(results))
+ 	expect_true(all(vapply(mzs, function(mz) any((results$peak.mz >= mz - tol) & (results$peak.mz <= mz + tol)), FUN.VALUE = TRUE)))
 
 	# Get 2 results per M/Z value
-	results <- db$searchMsPeaks(mzs, mz.tol = 0.1, max.results = 2, ms.mode = mode)
+	results <- db$searchMsPeaks(mzs, mz.tol = tol, max.results = 2, ms.mode = mode)
 	expect_is(results, 'data.frame')
 	expect_true(nrow(results) > 1)
 	expect_true('accession' %in% names(results))
 	expect_true('peak.mz' %in% names(results))
+ 	expect_true(all(vapply(mzs, function(mz) any((results$peak.mz >= mz - tol) & (results$peak.mz <= mz + tol)), FUN.VALUE = TRUE)))
 }
 
 # Test msmsSearch whe no IDs are found {{{1


### PR DESCRIPTION
Update PeakForest URLs.
Correct searchMsPeaks() for MassCsvFile.
Add ms.level field to searchMsPeaks().
Correct indexing in progress message.