### PR TITLE
Bug fix: correct generic test of searchForEntries.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -49,3 +49,6 @@ Changes in version 1.0.1 (2021-05-20)
 
 Changes in version 1.0.2 (2021-05-23)
 + Bug fix: correct return type of searchForEntries(), which now returns always a character vector and never NULL.
+
+Changes in version 1.0.3 (2021-05-26)
++ Bug fix: correct generic test of searchForEntries(), allowing testing with NA value.

--- a/R/generic_tests.R
+++ b/R/generic_tests.R
@@ -480,14 +480,13 @@ test.searchForEntries <- function(conn, opt=NULL) {
                 testthat::expect_is(v, 'character')
                 testthat::expect_gt(length(v), 0)
                 v <- v[[1]]
-                testthat::expect_true( ! is.na(v))
             }
             x <- list()
             x[[f]] <- v
             ids <- conn$searchForEntries(fields=x, max.results=max.results)
             
             # Test result
-            if (is.null(v) || v == '') {
+            if (is.null(v) || is.na(v) || v == '') {
                 testthat::expect_is(ids, 'character')
                 testthat::expect_length(ids, 0)
             }


### PR DESCRIPTION
Allows testing with NA value.